### PR TITLE
New argument, fixed bugs, CSV output

### DIFF
--- a/commands/merge_test.go
+++ b/commands/merge_test.go
@@ -1,0 +1,220 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/fuzzer/run"
+	"github.com/dolthub/fuzzer/types"
+)
+
+var baseRows = []run.Row{
+	{[]types.Value{types.TimeValue{"-838:31:51"}, types.TimeValue{"-553:00:01"}}, 1},
+	{[]types.Value{types.TimeValue{"-793:52:40"}, types.TimeValue{"198:43:35"}}, 1},
+	{[]types.Value{types.TimeValue{"-793:26:03"}, types.TimeValue{"715:26:13"}}, 1},
+	{[]types.Value{types.TimeValue{"-764:41:36"}, types.TimeValue{"-453:16:19"}}, 1},
+	{[]types.Value{types.TimeValue{"-690:22:04"}, types.TimeValue{"163:36:57"}}, 1},
+	{[]types.Value{types.TimeValue{"-684:57:11"}, types.TimeValue{"-284:39:55"}}, 1},
+	{[]types.Value{types.TimeValue{"-656:59:25"}, types.TimeValue{"394:55:53"}}, 1},
+	{[]types.Value{types.TimeValue{"-650:19:06"}, types.TimeValue{"-177:56:40"}}, 1},
+	{[]types.Value{types.TimeValue{"-589:39:43"}, types.TimeValue{"-434:53:33"}}, 1},
+	{[]types.Value{types.TimeValue{"-442:15:39"}, types.TimeValue{"758:18:25"}}, 1},
+	{[]types.Value{types.TimeValue{"-308:43:24"}, types.TimeValue{"178:04:43"}}, 1},
+	{[]types.Value{types.TimeValue{"-203:32:21"}, types.TimeValue{"-330:29:49"}}, 1},
+	{[]types.Value{types.TimeValue{"-178:55:18"}, types.TimeValue{"636:15:55"}}, 1},
+	{[]types.Value{types.TimeValue{"18:06:59"}, types.TimeValue{"-12:57:13"}}, 1},
+	{[]types.Value{types.TimeValue{"37:22:18"}, types.TimeValue{"-699:29:43"}}, 1},
+	{[]types.Value{types.TimeValue{"67:35:37"}, types.TimeValue{"347:22:17"}}, 1},
+	{[]types.Value{types.TimeValue{"124:04:30"}, types.TimeValue{"507:39:02"}}, 1},
+	{[]types.Value{types.TimeValue{"135:41:08"}, types.TimeValue{"-812:36:16"}}, 1},
+	{[]types.Value{types.TimeValue{"135:48:02"}, types.TimeValue{"-166:38:15"}}, 1},
+	{[]types.Value{types.TimeValue{"170:50:26"}, types.TimeValue{"465:34:49"}}, 1},
+	{[]types.Value{types.TimeValue{"220:24:44"}, types.TimeValue{"-607:19:42"}}, 1},
+	{[]types.Value{types.TimeValue{"272:18:02"}, types.TimeValue{"-450:21:45"}}, 1},
+	{[]types.Value{types.TimeValue{"286:30:14"}, types.TimeValue{"393:52:48"}}, 1},
+	{[]types.Value{types.TimeValue{"327:06:35"}, types.TimeValue{"-830:54:12"}}, 1},
+	{[]types.Value{types.TimeValue{"349:06:13"}, types.TimeValue{"-333:14:49"}}, 1},
+	{[]types.Value{types.TimeValue{"390:38:57"}, types.TimeValue{"11:05:46"}}, 1},
+	{[]types.Value{types.TimeValue{"390:57:07"}, types.TimeValue{"-689:08:04"}}, 1},
+	{[]types.Value{types.TimeValue{"461:43:15"}, types.TimeValue{"-333:06:18"}}, 1},
+	{[]types.Value{types.TimeValue{"490:08:46"}, types.TimeValue{"426:23:30"}}, 1},
+	{[]types.Value{types.TimeValue{"521:45:58"}, types.TimeValue{"-581:03:49"}}, 1},
+	{[]types.Value{types.TimeValue{"591:05:40"}, types.TimeValue{"-752:30:11"}}, 1},
+	{[]types.Value{types.TimeValue{"611:19:42"}, types.TimeValue{"74:25:13"}}, 1},
+	{[]types.Value{types.TimeValue{"657:24:06"}, types.TimeValue{"56:59:13"}}, 1},
+	{[]types.Value{types.TimeValue{"784:01:32"}, types.TimeValue{"-436:26:12"}}, 1},
+	{[]types.Value{types.TimeValue{"804:32:49"}, types.TimeValue{"831:04:17"}}, 1},
+}
+var ourRows = []run.Row{
+	{[]types.Value{types.TimeValue{"-824:18:01"}, types.TimeValue{"112:59:35"}}, 1},
+	{[]types.Value{types.TimeValue{"-785:36:38"}, types.TimeValue{"-137:17:16"}}, 1},
+	{[]types.Value{types.TimeValue{"-772:20:57"}, types.TimeValue{"71:59:30"}}, 1},
+	{[]types.Value{types.TimeValue{"-741:15:26"}, types.TimeValue{"-824:06:24"}}, 1},
+	{[]types.Value{types.TimeValue{"-711:30:59"}, types.TimeValue{"-397:46:07"}}, 1},
+	{[]types.Value{types.TimeValue{"-685:29:52"}, types.TimeValue{"201:59:01"}}, 1},
+	{[]types.Value{types.TimeValue{"-666:55:53"}, types.TimeValue{"-132:36:26"}}, 1},
+	{[]types.Value{types.TimeValue{"-662:42:35"}, types.TimeValue{"-730:17:54"}}, 1},
+	{[]types.Value{types.TimeValue{"-650:19:06"}, types.TimeValue{"-98:27:00"}}, 1},
+	{[]types.Value{types.TimeValue{"-622:14:57"}, types.TimeValue{"-228:01:55"}}, 1},
+	{[]types.Value{types.TimeValue{"-598:11:54"}, types.TimeValue{"218:57:58"}}, 1},
+	{[]types.Value{types.TimeValue{"-596:49:11"}, types.TimeValue{"-120:28:05"}}, 1},
+	{[]types.Value{types.TimeValue{"-528:48:35"}, types.TimeValue{"804:42:18"}}, 1},
+	{[]types.Value{types.TimeValue{"-512:45:34"}, types.TimeValue{"624:44:00"}}, 1},
+	{[]types.Value{types.TimeValue{"-466:34:30"}, types.TimeValue{"-375:59:14"}}, 1},
+	{[]types.Value{types.TimeValue{"-442:15:39"}, types.TimeValue{"758:18:25"}}, 1},
+	{[]types.Value{types.TimeValue{"-410:21:38"}, types.TimeValue{"63:36:31"}}, 1},
+	{[]types.Value{types.TimeValue{"-362:47:22"}, types.TimeValue{"-792:58:17"}}, 1},
+	{[]types.Value{types.TimeValue{"-351:46:53"}, types.TimeValue{"-112:48:40"}}, 1},
+	{[]types.Value{types.TimeValue{"-313:38:38"}, types.TimeValue{"625:05:21"}}, 1},
+	{[]types.Value{types.TimeValue{"-250:38:44"}, types.TimeValue{"-102:01:27"}}, 1},
+	{[]types.Value{types.TimeValue{"-247:54:10"}, types.TimeValue{"-115:49:08"}}, 1},
+	{[]types.Value{types.TimeValue{"-203:32:21"}, types.TimeValue{"-330:29:49"}}, 1},
+	{[]types.Value{types.TimeValue{"-178:55:18"}, types.TimeValue{"636:15:55"}}, 1},
+	{[]types.Value{types.TimeValue{"-127:36:58"}, types.TimeValue{"112:23:42"}}, 1},
+	{[]types.Value{types.TimeValue{"-36:03:54"}, types.TimeValue{"-200:04:01"}}, 1},
+	{[]types.Value{types.TimeValue{"-05:21:15"}, types.TimeValue{"-778:39:01"}}, 1},
+	{[]types.Value{types.TimeValue{"18:06:59"}, types.TimeValue{"-12:57:13"}}, 1},
+	{[]types.Value{types.TimeValue{"60:49:52"}, types.TimeValue{"29:13:21"}}, 1},
+	{[]types.Value{types.TimeValue{"67:35:37"}, types.TimeValue{"-163:40:26"}}, 1},
+	{[]types.Value{types.TimeValue{"90:45:49"}, types.TimeValue{"276:03:20"}}, 1},
+	{[]types.Value{types.TimeValue{"124:04:30"}, types.TimeValue{"507:39:02"}}, 1},
+	{[]types.Value{types.TimeValue{"135:41:08"}, types.TimeValue{"-812:36:16"}}, 1},
+	{[]types.Value{types.TimeValue{"135:48:02"}, types.TimeValue{"-166:38:15"}}, 1},
+	{[]types.Value{types.TimeValue{"170:50:26"}, types.TimeValue{"465:34:49"}}, 1},
+	{[]types.Value{types.TimeValue{"174:22:51"}, types.TimeValue{"587:43:29"}}, 1},
+	{[]types.Value{types.TimeValue{"198:14:52"}, types.TimeValue{"200:13:58"}}, 1},
+	{[]types.Value{types.TimeValue{"220:24:44"}, types.TimeValue{"-607:19:42"}}, 1},
+	{[]types.Value{types.TimeValue{"238:16:14"}, types.TimeValue{"632:05:47"}}, 1},
+	{[]types.Value{types.TimeValue{"286:30:14"}, types.TimeValue{"393:52:48"}}, 1},
+	{[]types.Value{types.TimeValue{"315:04:59"}, types.TimeValue{"420:20:07"}}, 1},
+	{[]types.Value{types.TimeValue{"325:59:39"}, types.TimeValue{"-222:40:59"}}, 1},
+	{[]types.Value{types.TimeValue{"327:06:35"}, types.TimeValue{"-830:54:12"}}, 1},
+	{[]types.Value{types.TimeValue{"366:29:56"}, types.TimeValue{"-527:11:02"}}, 1},
+	{[]types.Value{types.TimeValue{"380:43:51"}, types.TimeValue{"-740:20:15"}}, 1},
+	{[]types.Value{types.TimeValue{"384:40:08"}, types.TimeValue{"739:31:11"}}, 1},
+	{[]types.Value{types.TimeValue{"390:38:57"}, types.TimeValue{"11:05:46"}}, 1},
+	{[]types.Value{types.TimeValue{"410:41:26"}, types.TimeValue{"752:39:02"}}, 1},
+	{[]types.Value{types.TimeValue{"452:29:12"}, types.TimeValue{"-590:40:19"}}, 1},
+	{[]types.Value{types.TimeValue{"461:43:15"}, types.TimeValue{"-333:06:18"}}, 1},
+	{[]types.Value{types.TimeValue{"521:45:58"}, types.TimeValue{"-581:03:49"}}, 1},
+	{[]types.Value{types.TimeValue{"522:15:36"}, types.TimeValue{"-114:03:06"}}, 1},
+	{[]types.Value{types.TimeValue{"591:05:40"}, types.TimeValue{"-752:30:11"}}, 1},
+	{[]types.Value{types.TimeValue{"611:19:42"}, types.TimeValue{"74:25:13"}}, 1},
+	{[]types.Value{types.TimeValue{"657:24:06"}, types.TimeValue{"56:59:13"}}, 1},
+	{[]types.Value{types.TimeValue{"748:31:39"}, types.TimeValue{"-320:29:19"}}, 1},
+	{[]types.Value{types.TimeValue{"783:36:39"}, types.TimeValue{"-37:12:55"}}, 1},
+	{[]types.Value{types.TimeValue{"791:12:11"}, types.TimeValue{"-184:53:03"}}, 1},
+	{[]types.Value{types.TimeValue{"804:32:49"}, types.TimeValue{"831:04:17"}}, 1},
+}
+var theirRows = []run.Row{
+	{[]types.Value{types.TimeValue{"-650:19:06"}, types.TimeValue{"807:27:02"}}, 1},
+	{[]types.Value{types.TimeValue{"-641:17:35"}, types.TimeValue{"548:04:42"}}, 1},
+	{[]types.Value{types.TimeValue{"-553:26:28"}, types.TimeValue{"-208:03:57"}}, 1},
+	{[]types.Value{types.TimeValue{"-465:01:47"}, types.TimeValue{"434:11:26"}}, 1},
+	{[]types.Value{types.TimeValue{"-442:15:39"}, types.TimeValue{"758:18:25"}}, 1},
+	{[]types.Value{types.TimeValue{"-415:17:46"}, types.TimeValue{"-554:48:52"}}, 1},
+	{[]types.Value{types.TimeValue{"-323:25:39"}, types.TimeValue{"-265:29:29"}}, 1},
+	{[]types.Value{types.TimeValue{"-318:20:17"}, types.TimeValue{"806:29:33"}}, 1},
+	{[]types.Value{types.TimeValue{"-308:43:24"}, types.TimeValue{"-780:52:57"}}, 1},
+	{[]types.Value{types.TimeValue{"-297:21:37"}, types.TimeValue{"-01:28:16"}}, 1},
+	{[]types.Value{types.TimeValue{"-271:46:28"}, types.TimeValue{"633:14:36"}}, 1},
+	{[]types.Value{types.TimeValue{"-203:32:21"}, types.TimeValue{"-330:29:49"}}, 1},
+	{[]types.Value{types.TimeValue{"-188:27:24"}, types.TimeValue{"-373:51:16"}}, 1},
+	{[]types.Value{types.TimeValue{"-178:55:18"}, types.TimeValue{"636:15:55"}}, 1},
+	{[]types.Value{types.TimeValue{"-134:50:53"}, types.TimeValue{"488:47:21"}}, 1},
+	{[]types.Value{types.TimeValue{"06:11:25"}, types.TimeValue{"494:13:52"}}, 1},
+	{[]types.Value{types.TimeValue{"18:06:59"}, types.TimeValue{"-12:57:13"}}, 1},
+	{[]types.Value{types.TimeValue{"67:35:37"}, types.TimeValue{"347:22:17"}}, 1},
+	{[]types.Value{types.TimeValue{"80:49:57"}, types.TimeValue{"589:48:04"}}, 1},
+	{[]types.Value{types.TimeValue{"124:04:30"}, types.TimeValue{"-720:08:33"}}, 1},
+	{[]types.Value{types.TimeValue{"135:41:08"}, types.TimeValue{"-812:36:16"}}, 1},
+	{[]types.Value{types.TimeValue{"135:48:02"}, types.TimeValue{"-303:16:10"}}, 1},
+	{[]types.Value{types.TimeValue{"170:50:26"}, types.TimeValue{"465:34:49"}}, 1},
+	{[]types.Value{types.TimeValue{"199:40:15"}, types.TimeValue{"-234:10:03"}}, 1},
+	{[]types.Value{types.TimeValue{"220:24:44"}, types.TimeValue{"-607:19:42"}}, 1},
+	{[]types.Value{types.TimeValue{"235:34:08"}, types.TimeValue{"620:34:59"}}, 1},
+	{[]types.Value{types.TimeValue{"272:18:02"}, types.TimeValue{"-450:21:45"}}, 1},
+	{[]types.Value{types.TimeValue{"286:30:14"}, types.TimeValue{"393:52:48"}}, 1},
+	{[]types.Value{types.TimeValue{"336:26:36"}, types.TimeValue{"-327:13:07"}}, 1},
+	{[]types.Value{types.TimeValue{"339:30:09"}, types.TimeValue{"451:34:39"}}, 1},
+	{[]types.Value{types.TimeValue{"380:00:13"}, types.TimeValue{"659:34:29"}}, 1},
+	{[]types.Value{types.TimeValue{"381:20:06"}, types.TimeValue{"-242:45:50"}}, 1},
+	{[]types.Value{types.TimeValue{"390:38:57"}, types.TimeValue{"11:05:46"}}, 1},
+	{[]types.Value{types.TimeValue{"390:57:07"}, types.TimeValue{"-689:08:04"}}, 1},
+	{[]types.Value{types.TimeValue{"408:15:42"}, types.TimeValue{"-253:14:46"}}, 1},
+	{[]types.Value{types.TimeValue{"457:30:03"}, types.TimeValue{"-566:22:01"}}, 1},
+	{[]types.Value{types.TimeValue{"461:43:15"}, types.TimeValue{"-633:12:38"}}, 1},
+	{[]types.Value{types.TimeValue{"490:08:46"}, types.TimeValue{"426:23:30"}}, 1},
+	{[]types.Value{types.TimeValue{"501:43:59"}, types.TimeValue{"788:55:03"}}, 1},
+	{[]types.Value{types.TimeValue{"505:13:57"}, types.TimeValue{"-759:13:38"}}, 1},
+	{[]types.Value{types.TimeValue{"591:05:40"}, types.TimeValue{"-752:30:11"}}, 1},
+	{[]types.Value{types.TimeValue{"611:19:42"}, types.TimeValue{"74:25:13"}}, 1},
+	{[]types.Value{types.TimeValue{"646:35:52"}, types.TimeValue{"666:25:44"}}, 1},
+	{[]types.Value{types.TimeValue{"664:56:05"}, types.TimeValue{"-804:02:12"}}, 1},
+	{[]types.Value{types.TimeValue{"665:49:06"}, types.TimeValue{"689:31:33"}}, 1},
+	{[]types.Value{types.TimeValue{"715:33:23"}, types.TimeValue{"-114:32:08"}}, 1},
+	{[]types.Value{types.TimeValue{"776:41:04"}, types.TimeValue{"478:44:47"}}, 1},
+	{[]types.Value{types.TimeValue{"784:01:32"}, types.TimeValue{"-302:09:44"}}, 1},
+	{[]types.Value{types.TimeValue{"784:13:00"}, types.TimeValue{"156:51:29"}}, 1},
+	{[]types.Value{types.TimeValue{"804:32:49"}, types.TimeValue{"831:04:17"}}, 1},
+	{[]types.Value{types.TimeValue{"820:28:26"}, types.TimeValue{"04:04:14"}}, 1},
+	{[]types.Value{types.TimeValue{"821:15:04"}, types.TimeValue{"-05:51:15"}}, 1},
+}
+
+func TestMerge(t *testing.T) {
+	// This test isn't for verifying code but for stepping through it
+	tableName := "FBFIfNfOoi"
+	pkCols := []*run.Column{{Name: "nRYVZk", Type: &types.TimeInstance{}}}
+	nonPKCols := []*run.Column{{Name: "gL3kqk", Type: &types.TimeInstance{}}}
+	mt := &mergeTables{
+		tableName: tableName,
+		ours:      mustTable(t, nil, tableName, pkCols, nonPKCols, nil),
+		theirs:    mustTable(t, nil, tableName, pkCols, nonPKCols, nil),
+		base:      mustTable(t, nil, tableName, pkCols, nonPKCols, nil),
+		final:     nil,
+	}
+	err := mt.base.Data.Exec(rowsToInsertString(tableName, baseRows))
+	require.NoError(t, err)
+	err = mt.ours.Data.Exec(rowsToInsertString(tableName, ourRows))
+	require.NoError(t, err)
+	err = mt.theirs.Data.Exec(rowsToInsertString(tableName, theirRows))
+	require.NoError(t, err)
+	mtc, err := mt.ProcessMerge()
+	require.NoError(t, err)
+	require.NotNil(t, mtc)
+	allRows, err := mtc.final.Data.GetAllRows()
+	require.NoError(t, err)
+	require.NotNil(t, allRows)
+}
+
+func mustTable(t *testing.T, parent *run.Commit, name string, pkCols []*run.Column, nonPKCols []*run.Column, indexes []*run.Index) *run.Table {
+	tbl, err := run.NewTable(parent, name, pkCols, nonPKCols, indexes)
+	require.NoError(t, err)
+	return tbl
+}
+
+func rowsToInsertString(tableName string, rows []run.Row) string {
+	sb := strings.Builder{}
+	sb.Grow(128 * 1024)
+	for _, row := range rows {
+		sb.WriteString(fmt.Sprintf("INSERT INTO `%s` VALUES (%s);", tableName, row.SQLiteString()))
+	}
+	return sb.String()
+}

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/gocraft/dbr/v2 v2.7.1
 	github.com/komkom/toml v0.0.0-20210317065440-24f427ca88cc
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.7.0
 )

--- a/parameters/base.go
+++ b/parameters/base.go
@@ -122,6 +122,7 @@ type Types struct {
 type Arguments struct {
 	NumOfCycles      int
 	Timeout          time.Duration
+	FirstError       bool
 	ConfigPath       string
 	RepoFinishedPath string
 	RepoWorkingPath  string

--- a/run/branch.go
+++ b/run/branch.go
@@ -214,7 +214,7 @@ func (b *Branch) NewTable(c *Cycle) (*Table, error) {
 		Param1: table,
 	}
 	return table, c.UseInterface(1, func(f func(string) error) error {
-		return f(table.CreateString(false))
+		return f(table.CreateString(false, false))
 	})
 }
 

--- a/run/cycle.go
+++ b/run/cycle.go
@@ -307,7 +307,7 @@ func (c *Cycle) CliQuery(args ...string) (string, error) {
 	copy(formattedArgs, args)
 	for i, arg := range formattedArgs {
 		if strings.Contains(arg, " ") {
-			formattedArgs[i] = `"`+strings.ReplaceAll(arg, `"`, `\"`)+`"`
+			formattedArgs[i] = `"` + strings.ReplaceAll(arg, `"`, `\"`) + `"`
 		}
 	}
 

--- a/run/row.go
+++ b/run/row.go
@@ -99,6 +99,15 @@ func (r Row) SQLiteString() string {
 	return strings.Join(vals, ",")
 }
 
+// CSVString returns the row as a comma-separated string. Intended for CSV usage.
+func (r Row) CSVString() string {
+	vals := make([]string, len(r.Values))
+	for i := 0; i < len(vals); i++ {
+		vals[i] = r.Values[i].CSVString()
+	}
+	return strings.Join(vals, ",")
+}
+
 // Equals returns whether the given row is equivalent to the calling row.
 func (r Row) Equals(otherRow Row) bool {
 	if len(r.Values) != len(otherRow.Values) {

--- a/types/bigint.go
+++ b/types/bigint.go
@@ -131,3 +131,8 @@ func (v BigintValue) MySQLString() string {
 func (v BigintValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v BigintValue) CSVString() string {
+	return v.String()
+}

--- a/types/bigint_unsigned.go
+++ b/types/bigint_unsigned.go
@@ -135,3 +135,8 @@ func (v BigintUnsignedValue) MySQLString() string {
 func (v BigintUnsignedValue) SQLiteString() string {
 	return formatUint64Sqlite(uint64(v.Uint64Value))
 }
+
+// CSVString implements the interface Value.
+func (v BigintUnsignedValue) CSVString() string {
+	return v.String()
+}

--- a/types/binary.go
+++ b/types/binary.go
@@ -113,3 +113,8 @@ func (v BinaryValue) MySQLString() string {
 func (v BinaryValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v BinaryValue) CSVString() string {
+	return v.StringTerminating(34)
+}

--- a/types/bit.go
+++ b/types/bit.go
@@ -144,3 +144,8 @@ func (v BitValue) MySQLString() string {
 func (v BitValue) SQLiteString() string {
 	return formatUint64Sqlite(uint64(v.Uint64Value))
 }
+
+// CSVString implements the interface Value.
+func (v BitValue) CSVString() string {
+	return v.String()
+}

--- a/types/blob.go
+++ b/types/blob.go
@@ -62,12 +62,12 @@ func (i *BlobInstance) Get() (Value, error) {
 	if err != nil {
 		return NilValue{}, errors.Wrap(err)
 	}
-	return VarbinaryValue{StringValue(v)}, err
+	return BlobValue{StringValue(v)}, err
 }
 
 // TypeValue implements the TypeInstance interface.
 func (i *BlobInstance) TypeValue() Value {
-	return VarbinaryValue{StringValue("")}
+	return BlobValue{StringValue("")}
 }
 
 // Name implements the TypeInstance interface.
@@ -116,4 +116,9 @@ func (v BlobValue) MySQLString() string {
 // SQLiteString implements the Value interface.
 func (v BlobValue) SQLiteString() string {
 	return v.String()
+}
+
+// CSVString implements the interface Value.
+func (v BlobValue) CSVString() string {
+	return v.StringTerminating(34)
 }

--- a/types/char.go
+++ b/types/char.go
@@ -127,3 +127,8 @@ func (v CharValue) MySQLString() string {
 func (v CharValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v CharValue) CSVString() string {
+	return v.StringTerminating(34)
+}

--- a/types/date.go
+++ b/types/date.go
@@ -107,3 +107,8 @@ func (v DateValue) MySQLString() string {
 func (v DateValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v DateValue) CSVString() string {
+	return v.StringTerminating(34)
+}

--- a/types/datetime.go
+++ b/types/datetime.go
@@ -112,3 +112,8 @@ func (v DatetimeValue) MySQLString() string {
 func (v DatetimeValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v DatetimeValue) CSVString() string {
+	return v.StringTerminating(34)
+}

--- a/types/double.go
+++ b/types/double.go
@@ -124,3 +124,8 @@ func (v DoubleValue) SQLiteString() string {
 	bitPattern ^= (0xffffffffffffffff * (bitPattern >> 63)) + (0x8000000000000000 - (0x8000000000000000 * (bitPattern >> 63)))
 	return formatUint64Sqlite(bitPattern)
 }
+
+// CSVString implements the interface Value.
+func (v DoubleValue) CSVString() string {
+	return v.String()
+}

--- a/types/enum.go
+++ b/types/enum.go
@@ -173,3 +173,8 @@ func (v EnumValue) MySQLString() string {
 func (v EnumValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v EnumValue) CSVString() string {
+	return v.String()
+}

--- a/types/float.go
+++ b/types/float.go
@@ -124,3 +124,8 @@ func (v FloatValue) SQLiteString() string {
 	bitPattern ^= (0xffffffff * (bitPattern >> 31)) + (0x80000000 - (0x80000000 * (bitPattern >> 31)))
 	return formatUint32Sqlite(bitPattern)
 }
+
+// CSVString implements the interface Value.
+func (v FloatValue) CSVString() string {
+	return v.String()
+}

--- a/types/int.go
+++ b/types/int.go
@@ -131,3 +131,8 @@ func (v IntValue) MySQLString() string {
 func (v IntValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v IntValue) CSVString() string {
+	return v.String()
+}

--- a/types/int_unsigned.go
+++ b/types/int_unsigned.go
@@ -131,3 +131,8 @@ func (v IntUnsignedValue) MySQLString() string {
 func (v IntUnsignedValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v IntUnsignedValue) CSVString() string {
+	return v.String()
+}

--- a/types/longblob.go
+++ b/types/longblob.go
@@ -117,3 +117,8 @@ func (v LongblobValue) MySQLString() string {
 func (v LongblobValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v LongblobValue) CSVString() string {
+	return v.StringTerminating(34)
+}

--- a/types/longtext.go
+++ b/types/longtext.go
@@ -127,3 +127,8 @@ func (v LongtextValue) MySQLString() string {
 func (v LongtextValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v LongtextValue) CSVString() string {
+	return v.StringTerminating(34)
+}

--- a/types/mediumblob.go
+++ b/types/mediumblob.go
@@ -117,3 +117,8 @@ func (v MediumblobValue) MySQLString() string {
 func (v MediumblobValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v MediumblobValue) CSVString() string {
+	return v.StringTerminating(34)
+}

--- a/types/mediumint.go
+++ b/types/mediumint.go
@@ -129,3 +129,8 @@ func (v MediumintValue) MySQLString() string {
 func (v MediumintValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v MediumintValue) CSVString() string {
+	return v.String()
+}

--- a/types/mediumint_unsigned.go
+++ b/types/mediumint_unsigned.go
@@ -129,3 +129,8 @@ func (v MediumintUnsignedValue) MySQLString() string {
 func (v MediumintUnsignedValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v MediumintUnsignedValue) CSVString() string {
+	return v.String()
+}

--- a/types/mediumtext.go
+++ b/types/mediumtext.go
@@ -129,3 +129,8 @@ func (v MediumtextValue) MySQLString() string {
 func (v MediumtextValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v MediumtextValue) CSVString() string {
+	return v.StringTerminating(34)
+}

--- a/types/set.go
+++ b/types/set.go
@@ -182,3 +182,8 @@ func (v SetValue) MySQLString() string {
 func (v SetValue) SQLiteString() string {
 	return formatUint64Sqlite(uint64(v.Uint64Value))
 }
+
+// CSVString implements the interface Value.
+func (v SetValue) CSVString() string {
+	return v.String()
+}

--- a/types/smallint.go
+++ b/types/smallint.go
@@ -131,3 +131,8 @@ func (v SmallintValue) MySQLString() string {
 func (v SmallintValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v SmallintValue) CSVString() string {
+	return v.String()
+}

--- a/types/smallint_unsigned.go
+++ b/types/smallint_unsigned.go
@@ -131,3 +131,8 @@ func (v SmallintUnsignedValue) MySQLString() string {
 func (v SmallintUnsignedValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v SmallintUnsignedValue) CSVString() string {
+	return v.String()
+}

--- a/types/text.go
+++ b/types/text.go
@@ -129,3 +129,8 @@ func (v TextValue) MySQLString() string {
 func (v TextValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v TextValue) CSVString() string {
+	return v.StringTerminating(34)
+}

--- a/types/time.go
+++ b/types/time.go
@@ -110,6 +110,22 @@ func (v TimeValue) Name() string {
 	return "TIME"
 }
 
+// Compare implements the ValuePrimitive interface. This overrides the inner primitive's Compare function, as the inner
+// value does not sort properly based on the specific properties of this value.
+func (v TimeValue) Compare(other ValuePrimitive) int {
+	if otherTime, ok := other.(TimeValue); ok {
+		vVal := v.ToInt64Value()
+		otherVal := otherTime.ToInt64Value()
+		if vVal < otherVal {
+			return -1
+		} else if vVal > otherVal {
+			return 1
+		}
+		return 0
+	}
+	return v.StringValue.Compare(other)
+}
+
 // MySQLString implements the Value interface.
 func (v TimeValue) MySQLString() string {
 	return v.String()
@@ -117,6 +133,16 @@ func (v TimeValue) MySQLString() string {
 
 // SQLiteString implements the Value interface.
 func (v TimeValue) SQLiteString() string {
+	return v.ToInt64Value().String()
+}
+
+// CSVString implements the interface Value.
+func (v TimeValue) CSVString() string {
+	return v.StringTerminating(34)
+}
+
+// ToInt64Value returns this value as an Int64Value.
+func (v TimeValue) ToInt64Value() Int64Value {
 	divisions := strings.Split(string(v.StringValue), ":")
 	negativeMult := int64(1)
 	if divisions[0][0] == '-' {
@@ -135,5 +161,5 @@ func (v TimeValue) SQLiteString() string {
 	for i := 0; i < len(divisions[2]); i++ {
 		second = (second * 10) + int64(divisions[2][i]-'0')
 	}
-	return Int64Value(negativeMult * ((hour * 3600) + (minute * 60) + second)).String()
+	return Int64Value(negativeMult * ((hour * 3600) + (minute * 60) + second))
 }

--- a/types/timestamp.go
+++ b/types/timestamp.go
@@ -112,3 +112,8 @@ func (v TimestampValue) MySQLString() string {
 func (v TimestampValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v TimestampValue) CSVString() string {
+	return v.StringTerminating(34)
+}

--- a/types/tinyblob.go
+++ b/types/tinyblob.go
@@ -117,3 +117,8 @@ func (v TinyblobValue) MySQLString() string {
 func (v TinyblobValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v TinyblobValue) CSVString() string {
+	return v.StringTerminating(34)
+}

--- a/types/tinyint.go
+++ b/types/tinyint.go
@@ -131,3 +131,8 @@ func (v TinyintValue) MySQLString() string {
 func (v TinyintValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v TinyintValue) CSVString() string {
+	return v.String()
+}

--- a/types/tinyint_unsigned.go
+++ b/types/tinyint_unsigned.go
@@ -131,3 +131,8 @@ func (v TinyintUnsignedValue) MySQLString() string {
 func (v TinyintUnsignedValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v TinyintUnsignedValue) CSVString() string {
+	return v.String()
+}

--- a/types/tinytext.go
+++ b/types/tinytext.go
@@ -129,3 +129,8 @@ func (v TinytextValue) MySQLString() string {
 func (v TinytextValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v TinytextValue) CSVString() string {
+	return v.StringTerminating(34)
+}

--- a/types/value.go
+++ b/types/value.go
@@ -49,6 +49,8 @@ type Value interface {
 	MySQLString() string
 	// SQLiteString returns the Value as a string for insertion into SQLite specifically.
 	SQLiteString() string
+	// CSVString returns the Value as a string for insertion into a CSV file.
+	CSVString() string
 }
 
 // NilValue is the Value type of a nil. This is a full Value rather than a ValuePrimitive as it should not be built on
@@ -88,6 +90,11 @@ func (v NilValue) MySQLString() string {
 // SQLiteString implements the interface Value.
 func (v NilValue) SQLiteString() string {
 	return v.String()
+}
+
+// CSVString implements the interface Value.
+func (v NilValue) CSVString() string {
+	return ""
 }
 
 // Compare implements the interface ValuePrimitive.
@@ -511,10 +518,15 @@ var _ ValuePrimitive = StringValue("")
 
 // String implements the interface ValuePrimitive.
 func (v StringValue) String() string {
+	return v.StringTerminating(39)
+}
+
+// StringTerminating returns the string with the given character as the end terminals.
+func (v StringValue) StringTerminating(char byte) string {
 	out := make([]byte, len(v)+2)
 	copy(out[1:], v)
-	out[0] = 39
-	out[len(out)-1] = 39
+	out[0] = char
+	out[len(out)-1] = char
 	return *(*string)(unsafe.Pointer(&out))
 }
 

--- a/types/varbinary.go
+++ b/types/varbinary.go
@@ -117,3 +117,8 @@ func (v VarbinaryValue) MySQLString() string {
 func (v VarbinaryValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v VarbinaryValue) CSVString() string {
+	return v.StringTerminating(34)
+}

--- a/types/varchar.go
+++ b/types/varchar.go
@@ -132,3 +132,8 @@ func (v VarcharValue) MySQLString() string {
 func (v VarcharValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v VarcharValue) CSVString() string {
+	return v.StringTerminating(34)
+}

--- a/types/year.go
+++ b/types/year.go
@@ -131,3 +131,8 @@ func (v YearValue) MySQLString() string {
 func (v YearValue) SQLiteString() string {
 	return v.String()
 }
+
+// CSVString implements the interface Value.
+func (v YearValue) CSVString() string {
+	return v.String()
+}


### PR DESCRIPTION
This adds a few new features. The most interesting one is that merge errors now dump the internal data in the form of CSVs and a handy shell script that sets up a Dolt repo with the contents of the aforementioned CSVs. This makes it much easier to debug future issues.

The other noteworthy feature is the new `--first-error` argument. When this is supplied, the fuzzer will stop once an error has been encountered in any cycle.

Lastly there are a multitude of bug fixes, including those that have been creating the numerous amount of issues. The majority of those were caused by comparisons using the default string representation when they require a specialized representation when comparing. Due to the nature of the comparisons, they do not behave incorrectly on every run, which allowed them to slip through.