### PR TITLE
Allow fuzzer runs to be reproducible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+repos
+seed-out.bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.PHONY: test
+
+all: build test basic
+
+prep:
+	go mod tidy
+
+clean:
+	go clean
+	go mod tidy
+
+build: prep
+	go build .
+
+test: build
+	go test -v ./... -coverprofile="./test-coverage.out" -count=1
+
+test_coverage: test
+	go tool cover -html="./test-coverage.out" -o "./test-coverage.html"
+
+test_coverage_html: test_coverage
+	open "./test-coverage.html"
+
+basic: build
+	go run . basic --repo-working ./repos/working --cycles 1 --repo-finished ./repos/finished

--- a/config.toml
+++ b/config.toml
@@ -35,6 +35,8 @@ Delete_Successful_Runs = true
 Port = 3307
 Zip_Internal_Data = true # If true, creates a ZIP archive out of the contents of the internal data folder
 Delete_After_Zip = true # If true, deletes the original contents that were added to the ZIP archive
+Seed_Out_File = "./seed-out.bin" # The name of the file that will contain the seed data
+# Seed_In_File = "./previous/seed-out.bin" # The name of the file that will be used to seed the database
 
 [Types.Parameters]
 BINARY_Length = [1, 255]

--- a/parameters/base.go
+++ b/parameters/base.go
@@ -72,6 +72,8 @@ type Options struct {
 	Port              int64
 	ZipInternalData   bool
 	DeleteAfterZip    bool
+	SeedInFile        string
+	SeedOutFile       string
 }
 
 // Types represents all of the MySQL types available to the program.

--- a/parameters/base_convert.go
+++ b/parameters/base_convert.go
@@ -69,6 +69,8 @@ func convertConfigBase(cBase *configBase) (*Base, error) {
 	base.Options.Port = int64(cBase.Options.Port)
 	base.Options.ZipInternalData = cBase.Options.ZipInternalData
 	base.Options.DeleteAfterZip = cBase.Options.DeleteAfterZip
+	base.Options.SeedInFile = cBase.Options.SeedInFile
+	base.Options.SeedOutFile = cBase.Options.SeedOutFile
 
 	// Types.Parameters
 	if err := cBase.Types.Parameters.Normalize(); err != nil {

--- a/parameters/config_base.go
+++ b/parameters/config_base.go
@@ -207,6 +207,8 @@ type configOptions struct {
 	Port              uint64 `json:"Port"`
 	ZipInternalData   bool   `json:"Zip_Internal_Data"`
 	DeleteAfterZip    bool   `json:"Delete_After_Zip"`
+	SeedInFile        string `json:"Seed_In_File"`
+	SeedOutFile       string `json:"Seed_Out_File"`
 }
 
 // Validate checks if the read values are valid.

--- a/rand/rand_test.go
+++ b/rand/rand_test.go
@@ -1,0 +1,57 @@
+package rand_test
+
+import (
+	"bufio"
+	"github.com/dolthub/fuzzer/rand"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRand(t *testing.T) {
+	inBytes := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f}
+
+	outFile, err := os.CreateTemp(".", "seed-out.bin")
+	require.Nil(t, err)
+	err = outFile.Close()
+	require.Nil(t, err)
+	defer func() {
+		err = os.Remove(outFile.Name())
+		require.Nil(t, err)
+	}()
+
+	inFile, err := os.CreateTemp(".", "seed-in.bin")
+	require.Nil(t, err)
+	defer func() {
+		err = os.Remove(inFile.Name())
+		require.Nil(t, err)
+	}()
+	inWriter := bufio.NewWriter(inFile)
+	_, err = inWriter.Write(inBytes)
+	require.Nil(t, err)
+	err = inWriter.Flush()
+	require.Nil(t, err)
+	err = inFile.Close()
+	require.Nil(t, err)
+
+	err = rand.Configure(inFile.Name(), outFile.Name())
+	require.Nil(t, err)
+
+	r1, err := rand.Int64()
+	require.Nil(t, err)
+	require.Equal(t, int64(283686952306183), r1)
+
+	r2, err := rand.Int64()
+	require.Nil(t, err)
+	require.Equal(t, int64(579005069656919567), r2)
+
+	seedOutPath, err := rand.Finalize()
+	require.Nil(t, err)
+	absSeedOutPath, err := filepath.Abs(outFile.Name())
+	require.Equal(t, absSeedOutPath, seedOutPath)
+
+	outBytes, err := os.ReadFile(seedOutPath)
+	require.Nil(t, err)
+	require.Equal(t, inBytes, outBytes)
+}

--- a/run/cycle.go
+++ b/run/cycle.go
@@ -17,6 +17,7 @@ package run
 import (
 	"bytes"
 	"fmt"
+	"github.com/dolthub/fuzzer/rand"
 	"os"
 	"os/exec"
 	"strings"
@@ -168,6 +169,18 @@ func (c *Cycle) Run() (err error) {
 			_ = c.Logger.WriteLine(LogType_ERR, fmt.Sprintf("%+v", err))
 			_ = c.Logger.Close()
 			func() {
+				seedOutPath, rerr := rand.Finalize()
+				if rerr != nil {
+					fmt.Printf("encountered error finalizing randomizer: %+v\n", rerr)
+				}
+				if len(seedOutPath) > 0 {
+					src := seedOutPath
+					dest := c.Planner.Base.Arguments.RepoWorkingPath + c.Name + "/seed-out.bin"
+					renameErr := os.Rename(src, dest)
+					if renameErr != nil {
+						fmt.Printf("failed to move file %s to %s: %+v\n", src, dest, renameErr)
+					}
+				}
 				errFile, fileErr := os.OpenFile(c.Planner.Base.Arguments.RepoWorkingPath+c.Name+"/err.txt",
 					os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0777)
 				if fileErr != nil {


### PR DESCRIPTION
Allow fuzzer runs to be reproducible by writing all the random bytes to disk and allowing these to be read in again instead of generating new random bytes.

Testing:
1. clone repo and switch to branch `pavel/seed-files`
2. download `seed-out-sample.bin` from [here](https://drive.google.com/file/d/1wdJWXngoHYgS60grwYragJ7sRJSFUXxI/view?usp=share_link) (ping me if you're having issues, everyone at dolt should be able to access the file)
3. put `seed-out-sample.bin` anywhere you want, get an absolute path to it
4. run ` go run . basic --cycles 1 --seed-in-file "/REPLACE_DIR/seed-out-sample.bin"`
5. the fuzzer should fail with the following error
```txt
On table `jPJPfwiimT`, internal data contains ['0b5g7oJ4Bror6nKHFOXx4PaFGzsV25vTBRAb9y3lvGkTXk7wNJMKN7s1VfqtZGheng',203039471010,24,'.T.H%RYR40f=1k3!no51g+j0aV#ZDH2jlimrZ0A-m*D4~Ntqo|=RQU@C=8O1zTu#xCfmdsmONIYFD#_*R|FGE-oY090qP:HQL%@i7YHCM%5_an62YmYhx2NZW=*DApfk2k|EE.JME5+*AzpsC',4444581,'P@hUPrWU3N+_m~B21O@S=1n:3YaTV5KZ sN','-8.5133877482441e+133',39,321051466,15540992765122741661]
Dolt contains ['_fZTuQif416D9M_22ZZLb9YSkxPKD32CxzxvYGvjnEkcWH03kANw1Bz2dk6Gtwz8uy',134533899673,26,'q~#KwYTURq~479*NRO.p$P!e:0Osc u4Gq.IZT3*2ABX6tl0 %^Net_9JupagDn7-96Rig$Tkz4O2MQ.rqMtzgE wE_.lOnqVDt~HN44$ g_62uYUA1+t=FUsHIgyoJ#5=vd.99lzqg8Z7SBn',7589600,'@O5C^l$f|.@urmKSC-T^vjcF0RtH0wWMeO','3.418390753454234e-25',-26,-1891626247,8682083690239803681]
```